### PR TITLE
Removing unnecessary ref usage in Expand, Input, and List Prompts

### DIFF
--- a/src/renderer/components/prompts/expand.jsx
+++ b/src/renderer/components/prompts/expand.jsx
@@ -18,15 +18,13 @@ var ExpandPrompt = React.createClass({
     };
   },
 
-  _getRefName: function (name) {
+  _getKeyName: function (name) {
     return 'expand-item-' + name;
   },
 
-  _onClick: function (event) {
-    // Currently looking up on elems using query selector because material-ui
-    // doesn't provide a better api for accessing value of RadioButton elem
+  _onClick: function (answer) {
     this.setState({
-      answer: event.currentTarget.querySelector('input[type=radio]').value
+      answer: answer
     });
   },
 
@@ -38,16 +36,15 @@ var ExpandPrompt = React.createClass({
 
     var choices = this.props.choices.map(function (choice) {
 
-      var ref = this._getRefName(choice.name);
+      var key = this._getKeyName(choice.name);
 
       return (
         <RadioButton
-          key={ref}
-          ref={ref}
+          key={key}
           name={this.props.name}
           value={choice.value}
           label={choice.name}
-          onClick={this._onClick}
+          onClick={this._onClick.bind(this, choice.value)}
           defaultChecked={choice.value && this.state.answer === choice.value}
           className="list-prompt-list-item"
         />

--- a/src/renderer/components/prompts/input.jsx
+++ b/src/renderer/components/prompts/input.jsx
@@ -18,14 +18,10 @@ var InputPrompt = React.createClass({
     };
   },
 
-  _onChange: function () {
+  _onChange: function (answer) {
     this.setState({
-      answer: this.refs[this._getRefName()].getValue()
+      answer: answer
     });
-  },
-
-  _getRefName: function () {
-    return 'input-' + this.props.name + '-' + this.props.value;
   },
 
   render: function () {
@@ -33,12 +29,11 @@ var InputPrompt = React.createClass({
       <div className="input-prompt fieldset">
         <label htmlFor={this.props.name} style={{ background: this.props.color }}>{this.props.message}</label>
         <TextField
-          ref={this._getRefName()}
           className="input-prompt-elem"
           type={this.props.type}
           name={this.props.name}
           value={this.state.answer}
-          onChange={this._onChange}
+          onChange={this._onChange.bind(this, this.state.answer)}
         />
       </div>
     );

--- a/src/renderer/components/prompts/list.jsx
+++ b/src/renderer/components/prompts/list.jsx
@@ -18,14 +18,11 @@ var ListPrompt = React.createClass({
     };
   },
 
-  _getRefName: function (name) {
+  _getKeyName: function (name) {
     return 'list-item-' + name;
   },
 
-  _onClick: function (event) {
-    // Currently looking up on elems using query selector because material-ui
-    // doesn't provide a better api for accessing value of RadioButton elem
-    var value = event.currentTarget.querySelector('input[type=radio]').value;
+  _onClick: function (value) {
     this.setState({
       answer: this.props.choices.findIndex(function (item) {
         var itemValue = item.value || item;
@@ -39,16 +36,15 @@ var ListPrompt = React.createClass({
     var choices = this.props.choices.map(function (choice, index) {
 
       var name = choice.name || choice;
-      var ref = this._getRefName(name);
+      var key = this._getKeyName(name);
 
       return (
         <RadioButton
-          key={ref}
-          ref={ref}
+          key={key}
           name={this.props.name}
           value={name}
           label={name}
-          onClick={this._onClick}
+          onClick={this._onClick.bind(this, value)}
           defaultChecked={this.state.answer === index}
           className="list-prompt-list-item"
         />


### PR DESCRIPTION
We can get around querying the DOM by creating a bound function to the onChange event for the components we we are wrapping.

I would have updated Checkbox also, but I did not see the _onChange function being fired anywhere.