### PR TITLE
Implementing electron-compile for Yeoman App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 build/
+cache/
 node_modules
 npm-debug.log

--- a/package.json
+++ b/package.json
@@ -48,11 +48,11 @@
     "sinon": "^1.15.3"
   },
   "scripts": {
-    "start": "electron .",
+    "start": "electron . -r",
     "test": "npm run test-renderer && npm run test-main",
     "test-main": "mocha spec/main-process",
     "test-renderer": "scripts/test-renderer.js",
-    "build": "node scripts/build.js"
+    "build": "electron-compile --target ./cache src/ static/ && node scripts/build.js"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bootstrap": "^3.3.0",
     "classnames": "^2.1.2",
     "color": "^0.8.0",
-    "electron-compile": "^0.7.0",
+    "electron-compile": "^0.7.1",
     "findup-sync": "^0.2.1",
     "fix-path": "^1.1.0",
     "flux": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "bootstrap": "^3.3.0",
     "classnames": "^2.1.2",
     "color": "^0.8.0",
+    "electron-compile": "^0.7.0",
     "findup-sync": "^0.2.1",
     "fix-path": "^1.1.0",
     "flux": "^2.0.1",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -26,7 +26,8 @@ var packagerOptions = {
   prune: true,
   dir: '.',
   ignore: [
-    'node_modules/.bin'
+    'node_modules/.bin',
+    'node_modules/electron-compile/node_modules/electron-compilers'
   ]
 };
 

--- a/src/browser/app.js
+++ b/src/browser/app.js
@@ -1,0 +1,38 @@
+'use strict';
+
+var yargs = require('yargs');
+
+var shellStartTime = Date.now();
+
+process.on('uncaughtException', function (error) {
+  if (error == null) {
+    error = {};
+  }
+
+  if (error.message != null) {
+    console.error(error.message);
+  }
+
+  if (error.stack != null) {
+    console.error(error.stack);
+  }
+});
+
+var Application = require('./application');
+
+var args = parseCommandLine();
+new Application(args);
+
+console.log('App load time: ' + (Date.now() - shellStartTime) + 'ms');
+
+function parseCommandLine() {
+  var options = yargs(process.argv.slice(1)).wrap(100);
+
+  options.alias('t', 'test').boolean('t').describe('t', 'Run the specs and exit with error code on failures.');
+
+  var args = options.argv;
+
+  return {
+    test: args.test
+  };
+}

--- a/src/browser/application.js
+++ b/src/browser/application.js
@@ -1,170 +1,169 @@
-'use strict';
+import app              from 'app';
+import ipc              from 'ipc';
+import path             from 'path';
+import shell            from 'shell';
+import BrowserWindow    from 'browser-window';
+import { EventEmitter } from 'events';
+import _                from 'underscore-plus';
+import AppMenu          from './appmenu';
+import AppWindow        from './appwindow';
 
-var app = require('app');
-var ipc = require('ipc');
-var path = require('path');
-var shell = require('shell');
-var BrowserWindow = require('browser-window');
-var EventEmitter = require('events').EventEmitter;
-var _ = require('underscore-plus');
-var AppMenu = require('./appmenu');
-var AppWindow = require('./appwindow');
+class Application extends EventEmitter {
 
-/**
- * The application's class.
- *
- * It's the entry point into the application and maintains the global state of the application.
- *
- * @param {boolean} [options.test]          Boolean to determine if the application is running in test mode.
- * @param {boolean} [options.exitWhenDone]  Boolean to determine whether to automatically exit.
- */
-function Application (options) {
-  options = options || {};
-  this.pkgJson = require('../../package.json');
-  this.windows = [];
+  /**
+   * The application's class.
+   *
+   * It's the entry point into the application and maintains the global state of the application.
+   *
+   * @param {boolean} [options.test]          Boolean to determine if the application is running in test mode.
+   * @param {boolean} [options.exitWhenDone]  Boolean to determine whether to automatically exit.
+   */
+  constructor (options = {}) {
+    super();
+    this.pkgJson = require('../../package.json');
+    this.windows = [];
 
-  this.handleEvents();
-  this.openWithOptions(options);
+    this.handleEvents();
+    this.openWithOptions(options);
+  }
+
+  /**
+   * Opens a new window based on the options provided.
+   *
+   * @param {boolean} [options.test]          Boolean to determine if the application is running in test mode.
+   * @param {boolean} [options.exitWhenDone]  Boolean to determine whether to automatically exit.
+   */
+  openWithOptions (options) {
+    let newWindow;
+    let { test } = options;
+
+    if (test) {
+      if (options.exitWhenDone === undefined) {
+        options.exitWhenDone = true;
+      }
+      newWindow = this.openSpecsWindow(options);
+    } else {
+      newWindow = this.openWindow(options);
+    }
+
+    newWindow.show();
+    this.windows.push(newWindow);
+    newWindow.on('closed', () => {
+      this.removeAppWindow(newWindow);
+    });
+  }
+
+  /**
+   * Opens up a new AtomWindow to run specs within.
+   *
+   * @param {boolean} [options.exitWhenDone] Boolean to determine whether to automatically exit.
+   */
+  openSpecsWindow (options) {
+    let bootstrapScript;
+    let exitWhenDone = options.exitWhenDone;
+
+    try {
+      bootstrapScript = require.resolve(path.resolve(__dirname, 'spec', 'renderer-process', 'helpers', 'bootstrap'));
+    } catch (error) {
+      bootstrapScript = require.resolve(path.resolve(__dirname, '..', '..', 'spec', 'renderer-process', 'helpers', 'bootstrap'));
+    }
+
+    return new AppWindow({
+      bootstrapScript: bootstrapScript,
+      exitWhenDone: exitWhenDone,
+      isSpec: true,
+      title: `${this.pkgJson.productName}\'s Spec Suite`
+    });
+  }
+
+  /**
+   * Opens up a new AppWindow and runs the application.
+   */
+  openWindow () {
+    let appWindow;
+    appWindow = new AppWindow({
+      title: this.pkgJson.productName,
+      width: 1024,
+      height: 700
+    });
+    this.menu = new AppMenu({
+      pkg: this.pkgJson
+    });
+    this.menu.attachToWindow(appWindow);
+    this.menu.on('application:quit', function () {
+      app.quit();
+    });
+
+    this.menu.on('application:report-issue', () => {
+      shell.openExternal(this.pkgJson.bugs);
+    });
+
+    this.menu.on('window:reload', function () {
+      BrowserWindow.getFocusedWindow().reload();
+    });
+
+    this.menu.on('window:toggle-full-screen', function () {
+      let focusedWindow = BrowserWindow.getFocusedWindow();
+      let fullScreen = true;
+      if (focusedWindow.isFullScreen()) {
+        fullScreen = false;
+      }
+
+      focusedWindow.setFullScreen(fullScreen);
+    });
+
+    this.menu.on('window:toggle-dev-tools', function () {
+      BrowserWindow.getFocusedWindow().toggleDevTools();
+    });
+
+    this.menu.on('application:run-specs', () => {
+      return this.openWithOptions({
+        test: true,
+        exitWhenDone: false
+      });
+    });
+    return appWindow;
+  }
+
+  /**
+   * Removes the given window from the list of windows, so it can be GC'd.
+   *
+   * @param {AppWindow} appWindow The AppWindow to be removed
+   */
+  removeAppWindow (appWindow) {
+    this.windows.forEach((win, index) => {
+      if (win === appWindow) {
+        this.windows.splice(index, 1);
+      }
+    });
+  }
+
+  handleEvents () {
+    this.on('application:quit', function () {
+      return app.quit();
+    });
+
+    ipc.on('context-appwindow', (event) => {
+      let args = Array.prototype.slice.call(arguments, 1);
+      let appWindow = this.windowForEvent(event.sender);
+      appWindow.emit.apply(appWindow, args);
+    });
+
+    ipc.on('context-generator', (event) => {
+      let args = Array.prototype.slice.call(arguments, 1);
+      let appWindow = this.windowForEvent(event.sender);
+      appWindow.sendCommandToProcess.apply(appWindow, args);
+    });
+  }
+
+  // Returns the {AppWindow} for the given ipc event.
+  windowForEvent (sender) {
+    let win = BrowserWindow.fromWebContents(sender);
+    return _.find(this.windows, function (appWindow) {
+      return appWindow.window === win;
+    });
+  }
+
 }
 
-_.extend(Application.prototype, EventEmitter.prototype);
-
-/**
- * Opens a new window based on the options provided.
- *
- * @param {boolean} [options.test]          Boolean to determine if the application is running in test mode.
- * @param {boolean} [options.exitWhenDone]  Boolean to determine whether to automatically exit.
- */
-Application.prototype.openWithOptions = function (options) {
-  var newWindow;
-  var test = options.test;
-
-  if (test) {
-    if (options.exitWhenDone === undefined) {
-      options.exitWhenDone = true;
-    }
-    newWindow = this.openSpecsWindow(options);
-  } else {
-    newWindow = this.openWindow(options);
-  }
-
-  newWindow.show();
-  this.windows.push(newWindow);
-  newWindow.on('closed', function () {
-    this.removeAppWindow(newWindow);
-  }.bind(this));
-};
-
-/**
- * Opens up a new AtomWindow to run specs within.
- *
- * @param {boolean} [options.exitWhenDone] Boolean to determine whether to automatically exit.
- */
-Application.prototype.openSpecsWindow = function (options) {
-  var bootstrapScript;
-  var exitWhenDone = options.exitWhenDone;
-
-  try {
-    bootstrapScript = require.resolve(path.resolve(__dirname, 'spec', 'renderer-process', 'helpers', 'bootstrap'));
-  } catch (error) {
-    bootstrapScript = require.resolve(path.resolve(__dirname, '..', '..', 'spec', 'renderer-process', 'helpers', 'bootstrap'));
-  }
-
-  return new AppWindow({
-    bootstrapScript: bootstrapScript,
-    exitWhenDone: exitWhenDone,
-    isSpec: true,
-    title: this.pkgJson.productName + '\'s Spec Suite'
-  });
-};
-
-/**
- * Opens up a new AppWindow and runs the application.
- */
-Application.prototype.openWindow = function () {
-  var appWindow;
-  appWindow = new AppWindow({
-    title: this.pkgJson.productName,
-    width: 1024,
-    height: 700
-  });
-  this.menu = new AppMenu({
-    pkg: this.pkgJson
-  });
-  this.menu.attachToWindow(appWindow);
-  this.menu.on('application:quit', function () {
-    app.quit();
-  });
-
-  this.menu.on('application:report-issue', function () {
-    shell.openExternal(this.pkgJson.bugs);
-  }.bind(this));
-
-  this.menu.on('window:reload', function () {
-    BrowserWindow.getFocusedWindow().reload();
-  });
-
-  this.menu.on('window:toggle-full-screen', function () {
-    var focusedWindow = BrowserWindow.getFocusedWindow();
-    var fullScreen = true;
-    if (focusedWindow.isFullScreen()) {
-      fullScreen = false;
-    }
-
-    focusedWindow.setFullScreen(fullScreen);
-  });
-
-  this.menu.on('window:toggle-dev-tools', function () {
-    BrowserWindow.getFocusedWindow().toggleDevTools();
-  });
-
-  this.menu.on('application:run-specs', function () {
-    return this.openWithOptions({
-      test: true,
-      exitWhenDone: false
-    });
-  }.bind(this));
-  return appWindow;
-};
-
-/**
- * Removes the given window from the list of windows, so it can be GC'd.
- *
- * @param {AppWindow} appWindow The AppWindow to be removed
- */
-Application.prototype.removeAppWindow = function (appWindow) {
-  this.windows.forEach(function (win, index) {
-    if (win === appWindow) {
-      this.windows.splice(index, 1);
-    }
-  }.bind(this));
-};
-
-Application.prototype.handleEvents = function () {
-
-  this.on('application:quit', function () {
-    return app.quit();
-  });
-
-  ipc.on('context-appwindow', function (event) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var appWindow = this.windowForEvent(event.sender);
-    appWindow.emit.apply(appWindow, args);
-  }.bind(this));
-
-  ipc.on('context-generator', function (event) {
-    var args = Array.prototype.slice.call(arguments, 1);
-    var appWindow = this.windowForEvent(event.sender);
-    appWindow.sendCommandToProcess.apply(appWindow, args);
-  }.bind(this));
-};
-
-// Returns the {AppWindow} for the given ipc event.
-Application.prototype.windowForEvent = function (sender) {
-  var win = BrowserWindow.fromWebContents(sender);
-  return _.find(this.windows, function (appWindow) {
-    return appWindow.window === win;
-  });
-};
-
-module.exports = Application;
+export default Application;

--- a/src/browser/application.js
+++ b/src/browser/application.js
@@ -1,12 +1,12 @@
-import app              from 'app';
-import ipc              from 'ipc';
-import path             from 'path';
-import shell            from 'shell';
-import BrowserWindow    from 'browser-window';
+import app from 'app';
+import ipc from 'ipc';
+import path from 'path';
+import shell from 'shell';
+import BrowserWindow from 'browser-window';
 import { EventEmitter } from 'events';
-import _                from 'underscore-plus';
-import AppMenu          from './appmenu';
-import AppWindow        from './appwindow';
+import _ from 'underscore-plus';
+import AppMenu from './appmenu';
+import AppWindow from './appwindow';
 
 class Application extends EventEmitter {
 

--- a/src/browser/application.js
+++ b/src/browser/application.js
@@ -143,16 +143,14 @@ class Application extends EventEmitter {
       return app.quit();
     });
 
-    ipc.on('context-appwindow', (event) => {
-      let args = Array.prototype.slice.call(arguments, 1);
+    ipc.on('context-appwindow', (event, ...args) => {
       let appWindow = this.windowForEvent(event.sender);
-      appWindow.emit.apply(appWindow, args);
+      appWindow.emit(...args);
     });
 
-    ipc.on('context-generator', (event) => {
-      let args = Array.prototype.slice.call(arguments, 1);
+    ipc.on('context-generator', (event, ...args) => {
       let appWindow = this.windowForEvent(event.sender);
-      appWindow.sendCommandToProcess.apply(appWindow, args);
+      appWindow.sendCommandToProcess(...args);
     });
   }
 

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var app = require('app');
-var Application = require('./application');
 var yargs = require('yargs');
+var path = require('path');
 
 var shellStartTime = Date.now();
 
@@ -20,13 +20,15 @@ process.on('uncaughtException', function (error) {
   }
 });
 
-// Enable ES6 in the Renderer process
-app.commandLine.appendSwitch('js-flags', '--harmony');
-
 // Note: It's important that you don't do anything with Electron
 // unless it's after 'ready', or else mysterious bad things will happen
 // to you.
 app.on('ready', function () {
+  // Enable ES6 from this point on
+  require('electron-compile').initWithOptions({
+    cacheDir: path.join(__dirname, '../../cache')
+  });
+  var Application = require('./application');
 
   var args = parseCommandLine();
   new Application(args);

--- a/src/browser/main.js
+++ b/src/browser/main.js
@@ -1,49 +1,21 @@
-'use strict';
-
-var app = require('app');
-var yargs = require('yargs');
+var app  = require('app');
 var path = require('path');
+var fs   = require('fs');
 
-var shellStartTime = Date.now();
-
-process.on('uncaughtException', function (error) {
-  if (error == null) {
-    error = {};
-  }
-
-  if (error.message != null) {
-    console.error(error.message);
-  }
-
-  if (error.stack != null) {
-    console.error(error.stack);
-  }
-});
+// ROOT/src/browser/../../cache
+var cachePath = path.join(__dirname, '..', '..', 'cache');
+var devMode = (process.argv || []).indexOf('-r') !== -1;
 
 // Note: It's important that you don't do anything with Electron
 // unless it's after 'ready', or else mysterious bad things will happen
 // to you.
 app.on('ready', function () {
   // Enable ES6 from this point on
-  require('electron-compile').initWithOptions({
-    cacheDir: path.join(__dirname, '../../cache')
-  });
-  var Application = require('./application');
+  if (fs.statSyncNoException(cachePath) && !devMode) {
+    require('electron-compile').initForProduction(cachePath);
+  } else {
+    require('electron-compile').init();
+  }
 
-  var args = parseCommandLine();
-  new Application(args);
-
-  console.log('App load time: ' + (Date.now() - shellStartTime) + 'ms');
+  require('./app');
 });
-
-function parseCommandLine() {
-  var options = yargs(process.argv.slice(1)).wrap(100);
-
-  options.alias('t', 'test').boolean('t').describe('t', 'Run the specs and exit with error code on failures.');
-
-  var args = options.argv;
-
-  return {
-    test: args.test
-  };
-}

--- a/static/less/components/prompt-form.less
+++ b/static/less/components/prompt-form.less
@@ -1,6 +1,4 @@
-@prompt-form-width: 400px;
-@prompt-form-height: 300px;
-@prompt-form-margin: 24px;
+@import (reference) '../variables';
 
 .content {
   position: absolute;

--- a/static/less/components/prompts/checkbox.less
+++ b/static/less/components/prompts/checkbox.less
@@ -1,3 +1,5 @@
+@import (reference) '../../variables';
+
 @prompt-chekbox-item-height: 38px;
 
 .prompt form {

--- a/static/less/components/prompts/confirm.less
+++ b/static/less/components/prompts/confirm.less
@@ -1,3 +1,5 @@
+@import (reference) '../../variables';
+
 .prompt form {
 
   .confirm-options {

--- a/static/less/components/prompts/folder.less
+++ b/static/less/components/prompts/folder.less
@@ -1,3 +1,5 @@
+@import (reference) '../../variables';
+
 .prompt form {
 
   .select-folder-prompt {

--- a/static/less/components/prompts/input.less
+++ b/static/less/components/prompts/input.less
@@ -1,3 +1,5 @@
+@import (reference) '../../variables';
+
 @input-width: 320px;
 
 .prompt form {

--- a/static/less/components/prompts/list.less
+++ b/static/less/components/prompts/list.less
@@ -1,3 +1,5 @@
+@import (reference) '../../variables';
+
 @prompt-list-item-height: 16px;
 @prompt-list-item-margin: 38px;
 

--- a/static/less/variables.less
+++ b/static/less/variables.less
@@ -1,0 +1,3 @@
+@prompt-form-width: 400px;
+@prompt-form-height: 300px;
+@prompt-form-margin: 24px;


### PR DESCRIPTION
There's still some future work to be done here.

See: https://github.com/paulcbetts/electron-compile#how-can-i-precompile-my-code-for-release-time

The idea for release time would be to pre-compile everything on the command line in the build script, and then exclude the compilers folder in node modules in the ignore part of packagerOptions in `scripts/build.js` so that we don't ship all the compilers with the App.  In doing this, we would need to either set some environment variable in our app or some way to communicate to our `main.js` file that we're running in production so that instead of `require('electron-compile').initWithOptions`, we would `require('electron-compile').initForProduction`.

This gets us fairly far though and enables ES6 and beyond development within the app at the temporary (technical debt) cost of having 50 extra MB added to the application size.  I've updated `src/browser/application.js` to be an ES6 class as both an example and a test for the ES6 usage.