### PR TITLE
add react-tap-event-plugin and  adjust style for CompatibilityWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ps-tree": "^1.0.0",
     "q": "^1.0.1",
     "react": "^0.13.1",
+    "react-tap-event-plugin": "^0.1.7",
     "season": "^5.3.0",
     "semver": "^5.0.1",
     "underscore-plus": "^1.6.1",

--- a/src/renderer/app.jsx
+++ b/src/renderer/app.jsx
@@ -1,6 +1,9 @@
 'use strict';
 
 var React = require('react');
+
+require('react-tap-event-plugin')();
+
 var classSet = require('classnames');
 
 var CompatibilityWarning = require('./components/compatibility-warning.jsx');

--- a/src/renderer/components/compatibility-warning.jsx
+++ b/src/renderer/components/compatibility-warning.jsx
@@ -18,6 +18,8 @@ var CompatibilityWarning = React.createClass({
 
     var alertStyle = {
       display: this.props.active ? 'none' : 'block',
+      visibility: this.props.active ? 'hidden' : 'visible',
+      opacity: this.props.active ? 0 : 1,
       height: 'auto',
       lineHeight: '20px',
       paddingTop: 10,


### PR DESCRIPTION
The CompatibilityWarning component needs the react-tap-event-plugin for their tap events to work.

While fixing this I also noticed that since material-ui 0.10.4 the Snackbar also needs opacity and visibility styles to be set in order the be shown.

Fixes #71