### PR TITLE
Radio buttons are not working

### DIFF
--- a/src/renderer/components/prompt-form.jsx
+++ b/src/renderer/components/prompt-form.jsx
@@ -84,18 +84,6 @@ var PromptForm = React.createClass({
         />;
       };
 
-      var list = function (defaultValue) {
-        return <ListPrompt
-          key={question.name}
-          ref={question.name}
-          name={question.name}
-          choices={question.choices}
-          message={question.message}
-          defaultAnswer={question.default || defaultValue}
-          color={color}
-        />;
-      };
-
       var promptsByType = {
         input: input,
         password: input,
@@ -119,9 +107,17 @@ var PromptForm = React.createClass({
             color={color}
           />;
         },
-        // list prompt should start with at least first item selected
-        list: list.bind(null, 0),
-        rawlist: list,
+        list: function (defaultValue) {
+          return <ListPrompt
+            key={question.name}
+            ref={question.name}
+            name={question.name}
+            choices={question.choices}
+            message={question.message}
+            defaultAnswer={question.default || question.choices[0].value}
+            color={color}
+          />;
+        },
         expand: function createExpand() {
           console.log('createExpand');
           console.log(question);

--- a/src/renderer/components/prompts/expand.jsx
+++ b/src/renderer/components/prompts/expand.jsx
@@ -6,7 +6,7 @@ var mui = require('material-ui');
 var PromptMixin = require('./prompt-mixin');
 
 var RadioButton = mui.RadioButton;
-
+var RadioButtonGroup = mui.RadioButtonGroup;
 
 var ExpandPrompt = React.createClass({
 
@@ -45,7 +45,6 @@ var ExpandPrompt = React.createClass({
           value={choice.value}
           label={choice.name}
           onClick={this._onClick.bind(this, choice.value)}
-          defaultChecked={choice.value && this.state.answer === choice.value}
           className="list-prompt-list-item"
         />
       );
@@ -57,7 +56,9 @@ var ExpandPrompt = React.createClass({
           {this.props.message}
         </label>
         <div className="list-prompt-list">
-          {choices}
+          <RadioButtonGroup name={this.props.name} defaultSelected={this.state.answer}>
+            {choices}
+          </RadioButtonGroup>
         </div>
       </div>
     );

--- a/src/renderer/components/prompts/list.jsx
+++ b/src/renderer/components/prompts/list.jsx
@@ -6,6 +6,7 @@ var mui = require('material-ui');
 var PromptMixin = require('./prompt-mixin');
 
 var RadioButton = mui.RadioButton;
+var RadioButtonGroup = mui.RadioButtonGroup;
 
 
 var ListPrompt = React.createClass({
@@ -24,10 +25,7 @@ var ListPrompt = React.createClass({
 
   _onClick: function (value) {
     this.setState({
-      answer: this.props.choices.findIndex(function (item) {
-        var itemValue = item.value || item;
-        return itemValue === value;
-      }, null)
+      answer: value
     });
   },
 
@@ -42,10 +40,9 @@ var ListPrompt = React.createClass({
         <RadioButton
           key={key}
           name={this.props.name}
-          value={name}
+          value={choice.value}
           label={name}
-          onClick={this._onClick.bind(this, value)}
-          defaultChecked={this.state.answer === index}
+          onClick={this._onClick.bind(this, choice.value)}
           className="list-prompt-list-item"
         />
       );
@@ -57,7 +54,9 @@ var ListPrompt = React.createClass({
           {this.props.message}
         </label>
         <div className="list-prompt-list">
-          {choices}
+          <RadioButtonGroup name={this.props.name} defaultSelected={this.state.answer}>
+            {choices}
+          </RadioButtonGroup>
         </div>
       </div>
     );


### PR DESCRIPTION
Fixes #43 

Looks like Material-ui api has been changed and there is no props named `defaultChecked`. Instead they are using `<RadioButtonGroup/>`to select the `<RadioButton/>`.
https://github.com/callemall/material-ui/blob/master/src/radio-button.jsx#L141
 
Changes:
1. Use RadioButtonGroup
2. Remove unused rawlist and move list inline.