### PR TITLE
Add repository information

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,5 +56,9 @@
     "test": "scripts/test.js",
     "build": "electron-compile --target ./cache src/ static/ && node scripts/build.js"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/yeoman/yeoman-app"
+  }
 }


### PR DESCRIPTION
Removes the `npm WARN package.json yeoman-app@0.0.0 No repository field.` warning.

<img width="542" alt="screen shot 2015-10-30 at 6 24 30 pm" src="https://cloud.githubusercontent.com/assets/9198315/10860236/9654ffb2-7f33-11e5-81c8-0d8c820a5402.png">
