### PR TITLE
Getting started fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "q": "^1.0.1",
     "react": "^0.13.1",
     "react-redux": "^0.8.2",
-    "react-tap-event-plugin": "^0.1.7",
+    "react-tap-event-plugin": "0.1.7",
     "redux": "^1.0.1",
     "redux-thunk": "^0.1.0",
     "season": "^5.3.0",

--- a/src/renderer/containers/root.jsx
+++ b/src/renderer/containers/root.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import App from './App';
+import App from './app';
 import { Provider } from 'react-redux';
 import configureStore from '../stores/configure-store';
 import tapEventPlugin from 'react-tap-event-plugin';


### PR DESCRIPTION
##### Fixed react-tap-event-plugin breaking change upgrade (dont respect node version number). 
on npm 2.x it will crash because upgrade to react-tap-event-plugin required react==0.14. This project didn't respect node minor revision rule and added breaking change in minor revision, which failed with ~ or ^

##### Fixed case-sensitive error for loading app.jsx
App crash at start on case sensitive macs and linuxes.

![screen shot 2015-11-07 at 2 18 38 pm](https://cloud.githubusercontent.com/assets/98903/11016880/01325248-855c-11e5-8b77-0568eb1d0b64.png)
