### PR TITLE
Added npm debug scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 - [Getting Started](development/getting-started.md)
 - [Build instructions](development/build-instructions.md)
 - [Folder structure](development/folder-structure.md)
+- [Debugging](development/debugging.md)
 
 ## Events
 - [Events](events.md)

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -1,0 +1,16 @@
+# Debugging
+
+## Renderer Process
+
+It's possible to debug the Renderer process simply by opening the Web Developers tools <kbd>CMD</kbd>+<kbd>OPT</kbd>+<kbd>I</kbd> ( <kbd>CTRL</kbd>+<kbd>SHIFT</kbd>+<kbd>I</kbd> on Windows) or from the menu View > Developer > Toggle Developers Tools.
+
+## Main Process
+
+In order to debug the Main process we can use [node-inspector](https://github.com/node-inspector/node-inspector), here are the steps on how to use it:
+
+0. Install **node-inspector**: `npm install -g node-inspector`
+0. Starts the app in debug mode, run: `npm run debug`
+0. Starts the node inspector, run: `npm run inspector`
+
+Please note that we run `node-inspector` using its default ports, it uses port `8080` to run the inspector web interface and port `5858` to communicate between with the node process. For more info plese consult [node-inspector](https://github.com/node-inspector/node-inspector) docs.
+

--- a/package.json
+++ b/package.json
@@ -54,10 +54,16 @@
     "sandboxed-module": "^2.0.2",
     "sinon": "^1.15.3"
   },
+  "peerDependencies": {
+    "node-inspector": "^0.12.5"
+  },
   "scripts": {
     "start": "electron . -r",
     "test": "scripts/test.js",
     "pretest": "npm run lint",
+    "debug": "electron --debug . -r",
+    "preinspector": "open http://127.0.0.1:8080/?ws=127.0.0.1:8080&port=5858",
+    "inspector" : "node-inspector",
     "lint": "eslint --ext=js --ext=jsx src spec",
     "build": "electron-compile --target ./cache src/ static/ && node scripts/build.js"
   },


### PR DESCRIPTION
What do you think about this @stefanbuck ?

I imagine you were probably already using `node-inspector` (or something similar) on your side to debug the browser process but I think it would be a good idea to have these tasks declared as npm scripts and standardize the debug process.

My idea is to have the two tasks, that will need to be run in parallel:

- `npm run debug` starts the electron app in debug mode
- `npm run inspector` starts the node-inspector server and opens it on the browser