### PR TITLE
Better generator colors support using mui colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jasmine": "^2.1.1",
     "less": "^2.5.0",
     "lodash": "^3.6.0",
-    "material-colors": "^1.0.0",
     "material-ui": "^0.13.4",
     "node-uuid": "^1.4.3",
     "ps-tree": "^1.0.0",

--- a/src/renderer/utils/colors.js
+++ b/src/renderer/utils/colors.js
@@ -1,15 +1,34 @@
-import materialColors from 'material-colors/dist/colors.json';
+import { Styles } from 'material-ui';
 
-let arr = [];
-const stripColors = ['white', 'black'];
+// excludes problematic colors
+const stripColors = [
+  'brown700',
+  'brown800',
+  'brown900',
+  'blueGrey700',
+  'blueGrey800',
+  'blueGrey900',
+  'grey50',
+  'grey100',
+  'grey200',
+  'grey600',
+  'grey700',
+  'grey800',
+  'grey900',
+  'white',
+  'black',
+  'transparent',
+  'fullBlack',
+  'darkBlack',
+  'lightBlack',
+  'minBlack',
+  'faintBlack',
+  'fullWhite',
+  'darkWhite',
+  'lightWhite'
+];
 
-Object.keys(materialColors)
+export default Object.keys(Styles.Colors)
   .filter(color => stripColors.indexOf(color) === -1)
-  .forEach(function (key) {
-    Object.keys(materialColors[key]).forEach((colorKey) => {
-      arr.push(materialColors[key][colorKey]);
-    });
-  });
-
-export default arr;
+  .map(key => Styles.Colors[key]);
 


### PR DESCRIPTION
- Removed `material-colors` package
- Uses [material-ui colors](https://github.com/callemall/material-ui/blob/v0.14.2/src/styles/colors.js) instead
- Extended list of ignored colors

@stefanbuck 