### PR TITLE
Do not allow multiple empty lines

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,7 @@
     "no-multiple-empty-lines": [
       2,
       {
-        "max": 2
+        "max": 1
       }
     ],
     "no-use-before-define": [

--- a/src/renderer/components/grid.jsx
+++ b/src/renderer/components/grid.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import { Card, CardTitle } from 'material-ui';
 import GridItem from './grid-item.jsx';
 
-
 export default React.createClass({
   propTypes: {
     selectedGenerator: PropTypes.object,

--- a/src/renderer/components/prompt-form/index.jsx
+++ b/src/renderer/components/prompt-form/index.jsx
@@ -4,7 +4,6 @@ import promptFormStyles from '../../styles/components/prompt-form';
 import GetComponentStyle from '../mixins/get-component-style';
 import QuestionRenderer from './question-renderer-mixin.jsx';
 
-
 export default React.createClass({
   displayName: 'PromptForm',
 

--- a/src/renderer/components/prompt-form/label.jsx
+++ b/src/renderer/components/prompt-form/label.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styles from '../../styles/components/prompts';
 
-
 export default React.createClass({
   propTypes: {
     color: React.PropTypes.string.isRequired,
@@ -18,4 +17,3 @@ export default React.createClass({
     );
   }
 });
-

--- a/src/renderer/components/prompt-form/question-renderer-mixin.jsx
+++ b/src/renderer/components/prompt-form/question-renderer-mixin.jsx
@@ -5,7 +5,6 @@ import FolderPrompt from '../prompts/folder.jsx';
 import InputPrompt from '../prompts/input.jsx';
 import ListPrompt from '../prompts/list.jsx';
 
-
 export default {
 
   renderQuestion(question) {
@@ -97,4 +96,3 @@ export default {
     }
   }
 };
-

--- a/src/renderer/components/prompts/checkbox.jsx
+++ b/src/renderer/components/prompts/checkbox.jsx
@@ -5,7 +5,6 @@ import Container from '../prompt-form/container';
 import Label from '../prompt-form/label';
 import styles from '../../styles/components/prompts/checkbox';
 
-
 export default React.createClass({
   displayName: 'CheckboxPrompt',
 

--- a/src/renderer/components/prompts/confirm.jsx
+++ b/src/renderer/components/prompts/confirm.jsx
@@ -5,7 +5,6 @@ import Container from '../prompt-form/container';
 import Label from '../prompt-form/label';
 import styles from '../../styles/components/prompts/confirm';
 
-
 export default React.createClass({
   displayName: 'ConfirmPrompt',
 

--- a/src/renderer/components/prompts/folder.jsx
+++ b/src/renderer/components/prompts/folder.jsx
@@ -5,7 +5,6 @@ import Container from '../prompt-form/container';
 import Label from '../prompt-form/label';
 import styles from '../../styles/components/prompts/folder';
 
-
 export default React.createClass({
   displayName: 'FolderPrompt',
 

--- a/src/renderer/components/prompts/input.jsx
+++ b/src/renderer/components/prompts/input.jsx
@@ -5,7 +5,6 @@ import Container from '../prompt-form/container';
 import Label from '../prompt-form/label';
 import styles from '../../styles/components/prompts/input';
 
-
 export default React.createClass({
   displayName: 'InputPrompt',
 

--- a/src/renderer/components/prompts/list.jsx
+++ b/src/renderer/components/prompts/list.jsx
@@ -5,7 +5,6 @@ import Container from '../prompt-form/container';
 import Label from '../prompt-form/label';
 import styles from '../../styles/components/prompts/list';
 
-
 export default React.createClass({
   displayName: 'ListPrompt',
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -24,7 +24,6 @@ style.type = 'text/css';
 style.href = 'fonts.css';
 document.head.appendChild(style);
 
-
 insight.init(function () {
   // React entry-point
 

--- a/src/renderer/styles/components/prompts/checkbox.js
+++ b/src/renderer/styles/components/prompts/checkbox.js
@@ -17,5 +17,3 @@ export default {
     marginLeft: (base.margin / 2)
   }
 };
-
-


### PR DESCRIPTION
@ruyadorno discovered that some files are using double line breaks after the import statements and some not. By updating the eslint config this PR disallows multiple blank lines and removes all the remaining double line breaks. 


